### PR TITLE
Inject #UD on invalid vmcall, vmrun, vmload and vmsave instructions

### DIFF
--- a/memhv/memhv/Source/SVM/Handlers/SVM_HandleGenericVM.cpp
+++ b/memhv/memhv/Source/SVM/Handlers/SVM_HandleGenericVM.cpp
@@ -4,5 +4,8 @@ void SVM::HandleGenericSVM(const PVIRTUAL_PROCESSOR_DATA vpData, const PGUEST_CO
 {
     UNREFERENCED_PARAMETER(guestContext);
 
-    InjectGeneralProtectionException(vpData);
+    if (vpData->GuestVmcb.StateSaveArea.Cpl != 0)
+        InjectGeneralProtectionException(vpData);
+    else
+        InjectUndefinedOpcodeException(vpData);
 }

--- a/memhv/memhv/Source/SVM/Handlers/SVM_HandleVMCall.cpp
+++ b/memhv/memhv/Source/SVM/Handlers/SVM_HandleVMCall.cpp
@@ -114,7 +114,7 @@ void SVM::HandleVMCall(const PVIRTUAL_PROCESSOR_DATA vpData, const PGUEST_CONTEX
     }
     else
     {
-        InjectGeneralProtectionException(vpData);
+        InjectUndefinedOpcodeException(vpData);
         return;
     }
 

--- a/memhv/memhv/Source/SVM/Handlers/SVM_VMExit.cpp
+++ b/memhv/memhv/Source/SVM/Handlers/SVM_VMExit.cpp
@@ -11,17 +11,18 @@ void SVM::InjectGeneralProtectionException(const PVIRTUAL_PROCESSOR_DATA vpData)
     vpData->GuestVmcb.ControlArea.EventInj = event.AsUInt64;
 }
 
-/*void SVM::InjectUndefinedOpcodeException(const PVIRTUAL_PROCESSOR_DATA vpData)
+void SVM::InjectUndefinedOpcodeException(const PVIRTUAL_PROCESSOR_DATA vpData)
 {
     EVENTINJ event;
     event.AsUInt64 = 0;
     event.Fields.Vector = EXCEPTION_VECTOR_UNDEFINED_OPCODE;
     event.Fields.Type = INTERRUPT_TYPE_HARDWARE_EXCEPTION;
     event.Fields.ErrorCodeValid = 0;
-    event.Fields.Present = 1;
+    event.Fields.Valid = 1;
     vpData->GuestVmcb.ControlArea.EventInj = event.AsUInt64;
 }
 
+/*
 void SVM::InjectPageFaultException(const PVIRTUAL_PROCESSOR_DATA vpData, const ULONG64 address)
 {
     // https://wiki.osdev.org/Exceptions#Page_Fault

--- a/memhv/memhv/Source/SVM/Handlers/SVM_VMExit.h
+++ b/memhv/memhv/Source/SVM/Handlers/SVM_VMExit.h
@@ -3,6 +3,7 @@
 namespace SVM
 {
     void InjectGeneralProtectionException(PVIRTUAL_PROCESSOR_DATA vpData);
+    void InjectUndefinedOpcodeException(PVIRTUAL_PROCESSOR_DATA vpData);
 
     bool IsInUserland(PVIRTUAL_PROCESSOR_DATA vpData);
 


### PR DESCRIPTION
VMMCALL should raise #UD when not intercepted as said in AMD manual. Currently injecting #GP which is incorrect behavior.

for VMRUN/VMLOAD/VMSAVE, incompatibility only happens on kernel mode where it should raise #UD again.

https://www.0x04.net/doc/amd/33047.pdf page 20